### PR TITLE
Solution: Update move.toml dependencies to resolve test errors

### DIFF
--- a/day_01/Move.toml
+++ b/day_01/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_02/Move.toml
+++ b/day_02/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_02/README.md
+++ b/day_02/README.md
@@ -32,6 +32,23 @@ Tests in Move are functions marked with `#[test]`. They:
 - Help verify your code works correctly
 - Use assertions to check expected values
 
+Basic test syntax:
+``` move
+fun test_name() {
+    assert_eq!(1 + 1, 2)
+}
+```
+
+`assert_eq!` has to be called with the exclamation mark because it's a macro rather than a function. If you don't know what is macro, you can think that it's cooler function. It copy-pasted the actual code instead of calling the function.
+
+Note: In Move, you have to import the `assert_eq` from `std::unit_test` inside your module to use it. You can do it like:
+``` move
+#[test_only]
+use std::unit_test::assert_eq;
+```
+
+The good people tend to use `#[test_only]` to not pollute scope with test related things to speed up compiler performance. Also, it's good to declare it's not related with actual code.
+
 ## Your Task
 
 1. Open `sources/main.move`
@@ -46,6 +63,9 @@ Tests in Move are functions marked with `#[test]`. They:
 2. **Functions** - Learn function syntax and usage:
    [https://move-book.com/move-basics/function/](https://move-book.com/move-basics/function/)
 
+3. **Testing** - Learn testing fundamentals:
+   [https://move-book.com/move-basics/testing/](https://move-book.com/move-basics/testing/)
+
 ## Commit
 
 ```bash
@@ -54,4 +74,3 @@ sui move test
 git add day_02/
 git commit -m "Day 2: practice primitive types and functions"
 ```
-

--- a/day_02/README.md
+++ b/day_02/README.md
@@ -32,23 +32,6 @@ Tests in Move are functions marked with `#[test]`. They:
 - Help verify your code works correctly
 - Use assertions to check expected values
 
-Basic test syntax:
-``` move
-fun test_name() {
-    assert_eq!(1 + 1, 2)
-}
-```
-
-`assert_eq!` has to be called with the exclamation mark because it's a macro rather than a function. If you don't know what is macro, you can think that it's cooler function. It copy-pasted the actual code instead of calling the function.
-
-Note: In Move, you have to import the `assert_eq` from `std::unit_test` inside your module to use it. You can do it like:
-``` move
-#[test_only]
-use std::unit_test::assert_eq;
-```
-
-The good people tend to use `#[test_only]` to not pollute scope with test related things to speed up compiler performance. Also, it's good to declare it's not related with actual code.
-
 ## Your Task
 
 1. Open `sources/main.move`
@@ -63,9 +46,6 @@ The good people tend to use `#[test_only]` to not pollute scope with test relate
 2. **Functions** - Learn function syntax and usage:
    [https://move-book.com/move-basics/function/](https://move-book.com/move-basics/function/)
 
-3. **Testing** - Learn testing fundamentals:
-   [https://move-book.com/move-basics/testing/](https://move-book.com/move-basics/testing/)
-
 ## Commit
 
 ```bash
@@ -74,3 +54,4 @@ sui move test
 git add day_02/
 git commit -m "Day 2: practice primitive types and functions"
 ```
+

--- a/day_03/Move.toml
+++ b/day_03/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_04/Move.toml
+++ b/day_04/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_05/Move.toml
+++ b/day_05/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_06/Move.toml
+++ b/day_06/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_07/Move.toml
+++ b/day_07/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_08/Move.toml
+++ b/day_08/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_09/Move.toml
+++ b/day_09/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_10/Move.toml
+++ b/day_10/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_11/Move.toml
+++ b/day_11/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_12/Move.toml
+++ b/day_12/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_13/Move.toml
+++ b/day_13/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_14/Move.toml
+++ b/day_14/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_15/Move.toml
+++ b/day_15/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_16/Move.toml
+++ b/day_16/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_17/Move.toml
+++ b/day_17/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_18/Move.toml
+++ b/day_18/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_19/Move.toml
+++ b/day_19/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_20/Move.toml
+++ b/day_20/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"

--- a/day_21/Move.toml
+++ b/day_21/Move.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 challenge = "0x0"


### PR DESCRIPTION
## Description
This PR removes the explicit definitions of `Sui`, `MoveStdlib`, and `SuiSystem` from the `Move.toml` file. 

## Motivation
Recent versions of the Sui CLI and Move compiler now automatically handle these core dependencies. Manually including them triggers the following warning and disables the compiler's automated dependency management:
> "Dependencies on Bridge, MoveStdlib, Sui, and SuiSystem are automatically added, but this feature is disabled for your package because you have explicitly included dependencies on Sui."

Removing these manual entries ensures the project aligns with the current Sui Move best practices and resolves potential version mismatch conflicts.

## Changes
- Cleaned up `[dependencies]` in `Move.toml` by removing redundant framework packages.
- Enabled standard implicit dependency resolution.

## Testing
- Verified by running `sui move test` to ensure the package compiles successfully without explicit declarations.